### PR TITLE
Image loading

### DIFF
--- a/src/components/MenuSection.svelte
+++ b/src/components/MenuSection.svelte
@@ -54,11 +54,10 @@
           {#if item.productImage}
             <figure class="figure__menu-item-image">
               <a href={item.productImage}>
-                <!-- .split('') -->
                 <ImageLoader
-                  srcset={`
-                  ${item.productImage.substring(4, 0)}-400.webp 400w,
-                  ${item.productImage.substring(4, 0)}-400.jpeg `}
+                  imageSlug={item.productImageSlug}
+                  srcset={item.allProductImages}
+                  sizes={item.productImageSizes}
                   src={item.productImage}
                   alt={""}
                   rounded={true}
@@ -90,11 +89,12 @@
             <figure class="figure__menu-item-image">
               <a href={item.productImage}>
                 <ImageLoader
+                  imageSlug={item.productImageSlug}
+                  srcset={item.allProductImages}
+                  sizes={item.productImageSizes}
                   src={item.productImage}
-                  alt={item.altText}
+                  alt={""}
                   rounded={true}
-                  width={"2960"}
-                  height={"2960"}
                 />
               </a>
               <figcaption>
@@ -127,6 +127,9 @@
               <figure class="figure__menu-item-image">
                 <a href={item.productImage}>
                   <ImageLoader
+                    imageSlug={item.productImageSlug}
+                    srcset={item.allProductImages}
+                    sizes={item.productImageSizes}
                     src={item.productImage}
                     alt={""}
                     rounded={true}

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -9,19 +9,12 @@
   export let rounded;
   export let ariaLabel;
 
-  // let media = [
-  //   "(max-width: 600px)",
-  //   "(max-width: 1000x)",
-  //   "(max-width:"
-  // ]
-
   import { onMount } from "svelte";
 
   let loaded = false;
   let thisImage;
-  // let thisPicture;
-  // let thisError;
-  // let progress;
+  let imgSizesAttribute;
+  let imgSrcsetAttribute;
 
   onMount(() => {
     if (thisImage) {
@@ -30,18 +23,35 @@
       };
     }
   });
+
+  if (sizes) {
+    imgSizesAttribute = sizes
+      .map((size) => {
+        return `(${
+          size === "1200" ? "min" : "max"
+        }-width: ${size}px) ${size}px`;
+      })
+      .join(", ");
+  }
+  if (srcset) {
+    imgSrcsetAttribute = sizes
+      .map((size) => {
+        return (
+          src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.jpeg`) +
+          ` ${size}w`
+        );
+      })
+      .join(", ");
+  }
 </script>
 
 {#if srcset && sizes}
-  <!-- <picture bind:this={thisPicture} class:loaded> -->
   <picture>
     {#each sizes as size}
       <source
         type="image/webp"
         media={`
-          (${
-            sizes.indexOf(size) === sizes.length - 1 ? "min" : "max"
-          }-width: ${size}px)`}
+          (${size === "1200" ? "min" : "max"}-width: ${size}px)`}
         srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.webp`)}
       />
     {/each}
@@ -49,13 +59,19 @@
       <source
         type="image/jpeg"
         media={`
-          (${
-            sizes.indexOf(size) === sizes.length - 1 ? "min" : "max"
-          }-width: ${size}px)`}
+          (${size === "1200" ? "min" : "max"}-width: ${size}px)`}
         srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.jpeg`)}
       />
     {/each}
-    <img bind:this={thisImage} class:loaded class:rounded {src} {alt} />
+    <img
+      bind:this={thisImage}
+      class:loaded
+      class:rounded
+      {src}
+      {alt}
+      srcset={imgSrcsetAttribute}
+      sizes={imgSizesAttribute}
+    />
   </picture>
 {:else}
   <img

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -1,4 +1,5 @@
 <script>
+  export let imageSlug;
   export let srcset;
   export let sizes;
   export let src;
@@ -8,21 +9,53 @@
   export let rounded;
   export let ariaLabel;
 
+  // let media = [
+  //   "(max-width: 600px)",
+  //   "(max-width: 1000x)",
+  //   "(max-width:"
+  // ]
+
   import { onMount } from "svelte";
 
   let loaded = false;
   let thisImage;
+  // let thisPicture;
+  // let thisError;
+  // let progress;
 
   onMount(() => {
-    thisImage.onload = () => {
-      loaded = true;
-    };
+    if (thisImage) {
+      thisImage.onload = () => {
+        loaded = true;
+      };
+    }
   });
 </script>
 
-{#if srcset}
+{#if srcset && sizes}
+  <!-- <picture bind:this={thisPicture} class:loaded> -->
   <picture>
-    <source type="image/webp" media="(max-width: 600px)" srcset="" />
+    {#each sizes as size}
+      <source
+        type="image/webp"
+        media={`
+          (${
+            sizes.indexOf(size) === sizes.length - 1 ? "min" : "max"
+          }-width: ${size}px)`}
+        srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.webp`)}
+      />
+    {/each}
+    {#each sizes as size}
+      <source
+        type="image/jpeg"
+        media={`
+          (${
+            sizes.indexOf(size) === sizes.length - 1 ? "min" : "max"
+          }-width: ${size}px)`}
+        srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.jpeg`)}
+      />
+    {/each}
+    <img bind:this={thisImage} class:loaded class:rounded {src} {alt} />
   </picture>
 {:else}
   <img

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -20,18 +20,22 @@
   });
 </script>
 
-<img
-  {srcset}
-  {sizes}
-  {src}
-  {alt}
-  {width}
-  {height}
-  {ariaLabel}
-  class:loaded
-  class:rounded
-  bind:this={thisImage}
-/>
+{#if srcset}
+  <picture>
+    <source type="image/webp" media="(max-width: 600px)" srcset="" />
+  </picture>
+{:else}
+  <img
+    {src}
+    {alt}
+    {width}
+    {height}
+    {ariaLabel}
+    class:loaded
+    class:rounded
+    bind:this={thisImage}
+  />
+{/if}
 
 <style>
   img {

--- a/src/components/images/ImageLoader.svelte
+++ b/src/components/images/ImageLoader.svelte
@@ -1,4 +1,5 @@
 <script>
+  export let imageSlug;
   export let srcset;
   export let sizes;
   export let src;
@@ -15,6 +16,7 @@
 <IntersectionObserver once={true} let:intersecting>
   {#if intersecting}
     <Image
+      {imageSlug}
       {srcset}
       {sizes}
       {src}

--- a/src/routes/_home.js
+++ b/src/routes/_home.js
@@ -5,8 +5,8 @@ const fs = require('fs')
 export const homePage = home
   .map(({ metadata, html }) => {
     if (metadata.foodImage && metadata.hdImage) {
-      metadata.foodImage = metadata.foodImage.replace('.', 'https://www.que-ricas.com')
-      metadata.hdImage = metadata.hdImage.replace('.', 'https://www.que-ricas.com')
+      metadata.foodImage = metadata.foodImage.replace('.', 'https://www.que-ricas.com/g')
+      metadata.hdImage = metadata.hdImage.replace('.', 'https://www.que-ricas.com/g')
     }
     return ({ ...metadata, html })
   })

--- a/src/routes/_home.js
+++ b/src/routes/_home.js
@@ -5,9 +5,49 @@ const fs = require('fs')
 export const homePage = home
   .map(({ metadata, html }) => {
     if (metadata.foodImage && metadata.hdImage) {
+
+
+      let splitFoodImagePath = metadata.foodImage.split('/')
+      let splitHdImagePath = metadata.foodImage.split('/')
+
+      metadata.foodImageSlug = splitFoodImagePath[splitFoodImagePath.length - 1]
+        .split('.')[0]
+      
+      metadata.hdImageSlug = splitHdImagePath[splitHdImagePath.length - 1]
+        .split('.')[0]
+      
+      metadata.allFoodImages = []
+
+      metadata.allHdImages = []
+
+      
+      fs.readdirSync(`./static/g/images/home`).forEach(file => {
+        if (file.includes(metadata.foodImageSlug)) {
+          metadata.allFoodImages.push(file)
+        }
+        if (file.includes(metadata.hdImageSlug)) {
+          metadata.allHdImages.push(file)
+        }
+      })
+
+      metadata.allFoodImageSizes = getImageSizes(metadata.allFoodImages, ["400", "800", "1200"])
+      metadata.allHdImageSizes = getImageSizes(metadata.allHdImages, ["400", "800", "1200"])
+
+
       metadata.foodImage = metadata.foodImage.replace('.', 'https://www.que-ricas.com/g')
       metadata.hdImage = metadata.hdImage.replace('.', 'https://www.que-ricas.com/g')
     }
     return ({ ...metadata, html })
   })
 
+function getImageSizes(arr, sizesArr) {
+  let result = []
+  sizesArr.forEach((size) => {
+    arr.forEach((file) => {
+      if (file.includes(size) && !result.includes(size)) {
+        result.push(size)
+      }
+    })
+  })
+  return result
+}

--- a/src/routes/_home.js
+++ b/src/routes/_home.js
@@ -1,4 +1,6 @@
 import home from './../../markdowns/home/*.md'
+const fs = require('fs')
+
 
 export const homePage = home
   .map(({ metadata, html }) => {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,6 +16,8 @@
 
   export let home;
 
+  $: console.log(home);
+
   const [homepageContent] = home;
 
   const { page } = stores();
@@ -38,20 +40,24 @@
     <Card>
       <figure class="figure__hero-image">
         <ImageLoader
+          imageSlug={homepageContent.foodImageSlug}
+          srcset={homepageContent.allFoodImages}
+          sizes={homepageContent.allFoodImageSizes}
           src={homepageContent.foodImage}
           alt={homepageContent.foodImageAltText}
-          width={"1024"}
-          height={"1024"}
+          rounded={true}
         />
       </figure>
     </Card>
   {:else}
     <figure class="figure__hero-image">
       <ImageLoader
+        imageSlug={homepageContent.foodImageSlug}
+        srcset={homepageContent.allFoodImages}
+        sizes={homepageContent.allFoodImageSizes}
         src={homepageContent.foodImage}
         alt={homepageContent.foodImageAltText}
-        width={"1024"}
-        height={"1024"}
+        rounded={true}
       />
     </figure>
   {/if}
@@ -59,10 +65,12 @@
     <section>
       <figure class="figure__image">
         <ImageLoader
+          imageSlug={homepageContent.hdImageSlug}
+          srcset={homepageContent.allHdImages}
+          sizes={homepageContent.allHdImageSizes}
           src={homepageContent.hdImage}
           alt={homepageContent.hdImageAltText}
-          width={"500"}
-          height={"188"}
+          rounded={true}
         />
       </figure>
       <div class="text__article">

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -40,12 +40,6 @@ const allSections = [
   ...specials,
 ];
 
-// console.log(allSections)
-
-// allSections.forEach((x) => {
-//   if (x)
-// })
-
 
 function getTitle(section) {
   let result = section

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -6,20 +6,14 @@ import plattersContent from './../../../markdowns/menu/platters/**/*.md'
 import sidesAndExtrasContent from './../../../markdowns/menu/sides-and-extras/*.md'
 import specialsContent from './../../../markdowns/menu/specials/*.md'
 import startersContent from './../../../markdowns/menu/starters/*.md'
-<<<<<<< Updated upstream
 const fs = require('fs')
-=======
->>>>>>> Stashed changes
 
 
 function transform(menuSection) {
   let result = menuSection
     .map(({ metadata }) => {
       if (metadata.productImage) {
-<<<<<<< Updated upstream
         metadata.productImageSlug = 
-=======
->>>>>>> Stashed changes
         metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com/g')
       }
       return ({ ...metadata })

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -6,20 +6,12 @@ import plattersContent from './../../../markdowns/menu/platters/**/*.md'
 import sidesAndExtrasContent from './../../../markdowns/menu/sides-and-extras/*.md'
 import specialsContent from './../../../markdowns/menu/specials/*.md'
 import startersContent from './../../../markdowns/menu/starters/*.md'
-<<<<<<< Updated upstream
-const fs = require('fs')
-=======
->>>>>>> Stashed changes
 
 
 function transform(menuSection) {
   let result = menuSection
     .map(({ metadata }) => {
       if (metadata.productImage) {
-<<<<<<< Updated upstream
-        metadata.productImageSlug = 
-=======
->>>>>>> Stashed changes
         metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com/g')
       }
       return ({ ...metadata })

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -6,17 +6,46 @@ import plattersContent from './../../../markdowns/menu/platters/**/*.md'
 import sidesAndExtrasContent from './../../../markdowns/menu/sides-and-extras/*.md'
 import specialsContent from './../../../markdowns/menu/specials/*.md'
 import startersContent from './../../../markdowns/menu/starters/*.md'
+const fs = require('fs')
 
 
 function transform(menuSection) {
   let result = menuSection
     .map(({ metadata }) => {
       if (metadata.productImage) {
+
+        let splitPath = metadata.productImage.split('/')
+        metadata.productImageSlug = splitPath[splitPath.length - 1]
+          .split('.')[0]
+        
+        metadata.allProductImages = []
+        
+        fs.readdirSync(`./static/g/images/menu`).forEach(file => {
+          if (file.includes(metadata.productImageSlug)) {
+            metadata.allProductImages.push(file)
+          }
+        })
+
+        metadata.productImageSizes = getImageSizes(metadata.allProductImages, ["400", "800", "1200"])
+        
+        
         metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com/g')
       }
       return ({ ...metadata })
     })
     .sort((a, b) => (a.number > b.number ? 1 : -1))
+  return result
+}
+
+function getImageSizes(arr, sizesArr) {
+  let result = []
+  sizesArr.forEach((size) => {
+    arr.forEach((file) => {
+      if (file.includes(size) && !result.includes(size)) {
+        result.push(size)
+      }
+    })
+  })
   return result
 }
 

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -6,15 +6,15 @@ import plattersContent from './../../../markdowns/menu/platters/**/*.md'
 import sidesAndExtrasContent from './../../../markdowns/menu/sides-and-extras/*.md'
 import specialsContent from './../../../markdowns/menu/specials/*.md'
 import startersContent from './../../../markdowns/menu/starters/*.md'
-// import { stores } from "@sapper/app";
-// const { page } = stores()
+const fs = require('fs')
 
 
 function transform(menuSection) {
   let result = menuSection
     .map(({ metadata }) => {
       if (metadata.productImage) {
-        metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com')
+        metadata.productImageSlug = 
+        metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com/g')
       }
       return ({ ...metadata })
     })

--- a/src/routes/menu/_menu.js
+++ b/src/routes/menu/_menu.js
@@ -6,14 +6,20 @@ import plattersContent from './../../../markdowns/menu/platters/**/*.md'
 import sidesAndExtrasContent from './../../../markdowns/menu/sides-and-extras/*.md'
 import specialsContent from './../../../markdowns/menu/specials/*.md'
 import startersContent from './../../../markdowns/menu/starters/*.md'
+<<<<<<< Updated upstream
 const fs = require('fs')
+=======
+>>>>>>> Stashed changes
 
 
 function transform(menuSection) {
   let result = menuSection
     .map(({ metadata }) => {
       if (metadata.productImage) {
+<<<<<<< Updated upstream
         metadata.productImageSlug = 
+=======
+>>>>>>> Stashed changes
         metadata.productImage = metadata.productImage.replace('.', 'https://www.que-ricas.com/g')
       }
       return ({ ...metadata })

--- a/src/routes/menu/index.svelte
+++ b/src/routes/menu/index.svelte
@@ -17,6 +17,8 @@
 
   export let menu;
 
+  $: console.log(menu);
+
   const { page } = stores();
 
   function showMenuSection() {

--- a/src/routes/menu/index.svelte
+++ b/src/routes/menu/index.svelte
@@ -17,8 +17,6 @@
 
   export let menu;
 
-  $: console.log(menu);
-
   const { page } = stores();
 
   function showMenuSection() {

--- a/src/routes/story/_story.js
+++ b/src/routes/story/_story.js
@@ -1,4 +1,6 @@
 import story from './../../../markdowns/story/*.md'
+const fs = require('fs')
+
 
 export const aboutPage = story
   .map(({ metadata, html }) => {

--- a/src/routes/story/_story.js
+++ b/src/routes/story/_story.js
@@ -3,7 +3,7 @@ import story from './../../../markdowns/story/*.md'
 export const aboutPage = story
   .map(({ metadata, html }) => {
     if (metadata.image) {
-      metadata.image = metadata.image.replace('.', 'https://www.que-ricas.com')
+      metadata.image = metadata.image.replace('.', 'https://www.que-ricas.com/g')
     }
     return ({ ...metadata, html })
   })

--- a/src/routes/story/_story.js
+++ b/src/routes/story/_story.js
@@ -5,8 +5,34 @@ const fs = require('fs')
 export const aboutPage = story
   .map(({ metadata, html }) => {
     if (metadata.image) {
+
+      let splitPath = metadata.image.split('/')
+      metadata.imageSlug = splitPath[splitPath.length - 1]
+        .split('.')[0]
+      
+      metadata.allImages = []
+      
+      fs.readdirSync(`./static/g/images/story`).forEach(file => {
+        if (file.includes(metadata.imageSlug)) {
+          metadata.allImages.push(file)
+        }
+      })
+
+      metadata.imageSizes = getImageSizes(metadata.allImages, ["400", "800", "1200"])
       metadata.image = metadata.image.replace('.', 'https://www.que-ricas.com/g')
     }
     return ({ ...metadata, html })
   })
+
+function getImageSizes(arr, sizesArr) {
+  let result = []
+  sizesArr.forEach((size) => {
+    arr.forEach((file) => {
+      if (file.includes(size) && !result.includes(size)) {
+        result.push(size)
+      }
+    })
+  })
+  return result
+}
 

--- a/src/routes/story/index.svelte
+++ b/src/routes/story/index.svelte
@@ -16,6 +16,8 @@
 
   export let story;
 
+  $: console.log(story);
+
   const [darStory, saharStory] = story;
 
   const { page } = stores();
@@ -34,10 +36,11 @@
     <section>
       <figure class="image__article sahar">
         <ImageLoader
+          imageSlug={saharStory.imageSlug}
+          srcset={saharStory.allImages}
+          sizes={saharStory.imageSizes}
           src={saharStory.image}
           alt={saharStory.altText}
-          width={"3024"}
-          height={"3024"}
           rounded={true}
         />
       </figure>
@@ -51,11 +54,12 @@
     <section>
       <figure class="image__article dar">
         <ImageLoader
+          imageSlug={darStory.imageSlug}
+          srcset={darStory.allImages}
+          sizes={darStory.imageSizes}
           src={darStory.image}
           alt={darStory.altText}
           rounded={true}
-          width={"453"}
-          height={"453"}
         />
       </figure>
       <div class="text__article">


### PR DESCRIPTION
Added option to render responsive images via ImageLoader component by feeding unique props.  This was some gnarly hacking that's almost certainly messier than it should be, but I got it working.

Serving the processed webp images in 3 different sizes, along with 3 sizes of jpegs for browsers that don't support webp, with fallback to the original source jpeg image if needed.

Beautiful.