### PR TITLE
try putting font-display:swap on body element to mitigate CLS

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -137,6 +137,7 @@ body {
   background-position-y: 50%;
   background-size: cover;
   background-repeat: none;
+  font-display: swap;
 }
 
 :focus {


### PR DESCRIPTION
font-display property was on the @font-face declaration for the custom font. This doesn't look like it's actually registering as a property on body in the browser. 

Try adding font-display:swap directly onto body to mitigate CLS