### PR TITLE
Cleanup

### DIFF
--- a/src/components/MenuSection.svelte
+++ b/src/components/MenuSection.svelte
@@ -56,9 +56,10 @@
               <a href={item.productImage}>
                 <ImageLoader
                   imageSlug={item.productImageSlug}
-                  srcset={item.allProductImages}
-                  sizes={item.productImageSizes}
+                  allImages={item.allProductImages}
+                  processedImageSizes={item.productImageSizes}
                   src={item.productImage}
+                  sizes={"160px"}
                   alt={""}
                   rounded={true}
                 />
@@ -90,9 +91,10 @@
               <a href={item.productImage}>
                 <ImageLoader
                   imageSlug={item.productImageSlug}
-                  srcset={item.allProductImages}
-                  sizes={item.productImageSizes}
+                  allImages={item.allProductImages}
+                  processedImageSizes={item.productImageSizes}
                   src={item.productImage}
+                  sizes={"160px"}
                   alt={""}
                   rounded={true}
                 />
@@ -128,9 +130,10 @@
                 <a href={item.productImage}>
                   <ImageLoader
                     imageSlug={item.productImageSlug}
-                    srcset={item.allProductImages}
-                    sizes={item.productImageSizes}
+                    allImages={item.allProductImages}
+                    processedImageSizes={item.productImageSizes}
                     src={item.productImage}
+                    sizes={"160px"}
                     alt={""}
                     rounded={true}
                   />

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -1,6 +1,7 @@
 <script>
   export let imageSlug;
-  export let srcset;
+  export let allImages;
+  export let processedImageSizes;
   export let sizes;
   export let src;
   export let alt;
@@ -13,8 +14,6 @@
 
   let loaded = false;
   let thisImage;
-  let imgSizesAttribute;
-  let imgSrcsetAttribute;
 
   onMount(() => {
     if (thisImage) {
@@ -24,55 +23,45 @@
     }
   });
 
-  if (sizes) {
-    imgSizesAttribute = sizes
-      .map((size) => {
-        return `(${
-          size === "1200" ? "min" : "max"
-        }-width: ${size}px) ${size}px`;
-      })
-      .join(", ");
-  }
-  if (srcset) {
-    imgSrcsetAttribute = sizes
-      .map((size) => {
-        return (
-          src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.jpeg`) +
-          ` ${size}w`
-        );
-      })
-      .join(", ");
+  if (processedImageSizes) {
+    processedImageSizes.reverse();
   }
 </script>
 
-{#if srcset && sizes}
+{#if allImages && processedImageSizes}
   <picture>
-    {#each sizes as size}
+    {#each processedImageSizes as size}
       <source
         type="image/webp"
         media={`
-          (${size === "1200" ? "min" : "max"}-width: ${size}px)`}
-        srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.webp`)}
+          (min-width: ${size === "400" ? "10" : size}px)`}
+        srcset={src.replace(
+          `${imageSlug}.jpeg`,
+          `${imageSlug}-${size}.webp ${size}w`
+        )}
+        {sizes}
       />
     {/each}
-    {#each sizes as size}
+    {#each processedImageSizes as size}
       <source
         type="image/jpeg"
         media={`
-          (${size === "1200" ? "min" : "max"}-width: ${size}px)`}
-        srcset={src.replace(`${imageSlug}.jpeg`, `${imageSlug}-${size}.jpeg`)}
+          (min-width: ${size === "400" ? "10" : size}px)`}
+        srcset={src.replace(
+          `${imageSlug}.jpeg`,
+          `${imageSlug}-${size}.jpeg ${size}w`
+        )}
+        {sizes}
       />
     {/each}
     <img
       bind:this={thisImage}
       class:loaded
       class:rounded
-      {width}
-      {height}
       {src}
       {alt}
-      srcset={imgSrcsetAttribute}
-      sizes={imgSizesAttribute}
+      {width}
+      {height}
     />
   </picture>
 {:else}

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -54,15 +54,7 @@
         {sizes}
       />
     {/each}
-    <img
-      bind:this={thisImage}
-      class:loaded
-      class:rounded
-      {src}
-      {alt}
-      {width}
-      {height}
-    />
+    <img bind:this={thisImage} class:loaded class:rounded {src} {alt} />
   </picture>
 {:else}
   <img

--- a/src/components/images/ImageLoader.svelte
+++ b/src/components/images/ImageLoader.svelte
@@ -1,7 +1,8 @@
 <script>
   export let imageSlug;
-  export let srcset;
+  export let allImages;
   export let sizes;
+  export let processedImageSizes;
   export let src;
   export let alt;
   export let width;
@@ -17,10 +18,11 @@
   {#if intersecting}
     <Image
       {imageSlug}
-      {srcset}
-      {sizes}
+      {allImages}
+      {processedImageSizes}
       {src}
       {alt}
+      {sizes}
       {ariaLabel}
       {width}
       {height}

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -30,9 +30,6 @@
 <Footer {socialIcons} />
 
 <style>
-  :global(main) {
-    min-height: 100vh;
-  }
   :global(body) {
     font-size: 85%;
   }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -56,8 +56,7 @@
         processedImageSizes={homepageContent.allFoodImageSizes}
         src={homepageContent.foodImage}
         alt={homepageContent.foodImageAltText}
-        width={"1024"}
-        height={"1024"}
+        sizes={`(max-width: 960px) 100vw, (min-width: 961px) 90vw, (min-width: 1150px) 1166px`}
         rounded={true}
       />
     </figure>
@@ -71,8 +70,7 @@
           processedImageSizes={homepageContent.allHdImageSizes}
           src={homepageContent.hdImage}
           alt={homepageContent.hdImageAltText}
-          width={"500"}
-          height={"188"}
+          sizes={`(max-width: 400px) 100vw, (min-width: 480px) 480px`}
           rounded={true}
         />
       </figure>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -39,12 +39,11 @@
       <figure class="figure__hero-image">
         <ImageLoader
           imageSlug={homepageContent.foodImageSlug}
-          srcset={homepageContent.allFoodImages}
-          sizes={homepageContent.allFoodImageSizes}
+          allImages={homepageContent.allFoodImages}
+          processedImageSizes={homepageContent.allFoodImageSizes}
           src={homepageContent.foodImage}
           alt={homepageContent.foodImageAltText}
-          width={"1024"}
-          height={"1024"}
+          sizes={`(max-width: 960px) 100vw, (min-width: 961px) 90vw, (min-width: 1150px) 1166px`}
           rounded={true}
         />
       </figure>
@@ -53,8 +52,8 @@
     <figure class="figure__hero-image">
       <ImageLoader
         imageSlug={homepageContent.foodImageSlug}
-        srcset={homepageContent.allFoodImages}
-        sizes={homepageContent.allFoodImageSizes}
+        allImages={homepageContent.allFoodImages}
+        processedImageSizes={homepageContent.allFoodImageSizes}
         src={homepageContent.foodImage}
         alt={homepageContent.foodImageAltText}
         width={"1024"}
@@ -68,8 +67,8 @@
       <figure class="figure__image">
         <ImageLoader
           imageSlug={homepageContent.hdImageSlug}
-          srcset={homepageContent.allHdImages}
-          sizes={homepageContent.allHdImageSizes}
+          allImages={homepageContent.allHdImages}
+          processedImageSizes={homepageContent.allHdImageSizes}
           src={homepageContent.hdImage}
           alt={homepageContent.hdImageAltText}
           width={"500"}
@@ -95,6 +94,7 @@
     border: 3px;
     border-color: #4f86f7;
     border-bottom-style: outset;
+    min-height: 55vh;
   }
 
   .figure__image {
@@ -111,6 +111,12 @@
   @media (min-width: 400px) {
     .figure__hero-image {
       border: none;
+    }
+  }
+
+  @media (min-width: 960px) {
+    .figure__hero-image {
+      min-height: 60vh;
     }
   }
 </style>

--- a/src/routes/menu/index.svelte
+++ b/src/routes/menu/index.svelte
@@ -61,13 +61,6 @@
   </div>
 </article>
 
-<!-- <BaseSEO
-  title="Menu"
-  description="Our menu features empanadas, arepas, pabellon bowls, churros, local specialties, lunch specials, gluten free and vegan options"
-  canonical={`https://${$page.host}${$page.path}`}
-  image={menu.seo.image}
-  altText={menu.seo.altText}
-/> -->
 <style>
   div {
     display: none;

--- a/src/routes/story/index.svelte
+++ b/src/routes/story/index.svelte
@@ -35,8 +35,8 @@
       <figure class="image__article sahar">
         <ImageLoader
           imageSlug={saharStory.imageSlug}
-          srcset={saharStory.allImages}
-          sizes={saharStory.imageSizes}
+          allImages={saharStory.allImages}
+          processedImageSizes={saharStory.imageSizes}
           src={saharStory.image}
           alt={saharStory.altText}
           width={"3024"}
@@ -55,8 +55,8 @@
       <figure class="image__article dar">
         <ImageLoader
           imageSlug={darStory.imageSlug}
-          srcset={darStory.allImages}
-          sizes={darStory.imageSizes}
+          allImages={darStory.allImages}
+          processedImageSizes={darStory.imageSizes}
           src={darStory.image}
           alt={darStory.altText}
           width={"453"}

--- a/src/routes/story/index.svelte
+++ b/src/routes/story/index.svelte
@@ -39,8 +39,7 @@
           processedImageSizes={saharStory.imageSizes}
           src={saharStory.image}
           alt={saharStory.altText}
-          width={"3024"}
-          height={"3024"}
+          sizes={`(min-width: 1530px) 466px, (min-width: 960px) 27vw, (min-width: 10px) 38vw`}
           rounded={true}
         />
       </figure>
@@ -59,8 +58,7 @@
           processedImageSizes={darStory.imageSizes}
           src={darStory.image}
           alt={darStory.altText}
-          width={"453"}
-          height={"453"}
+          sizes={`(min-width: 1530px) 466px, (min-width: 960px) 27vw, (min-width: 10px) 38vw`}
           rounded={true}
         />
       </figure>

--- a/static/global.css
+++ b/static/global.css
@@ -136,7 +136,7 @@ body {
   background-position-x: 50%;
   background-position-y: 50%;
   background-size: cover;
-  background-repeat: none;
+  background-repeat: no-repeat;
   font-display: swap;
 }
 

--- a/static/global.css
+++ b/static/global.css
@@ -137,7 +137,6 @@ body {
   background-position-y: 50%;
   background-size: cover;
   background-repeat: no-repeat;
-  font-display: swap;
 }
 
 :focus {


### PR DESCRIPTION
- Get sizes attribute working on responsive images. This is good to understand for the future, big win
- Add min-height in vh units to the figure that wraps the hero image so it doesn't cause CLS. Looks like this should do the trick. Wasted a lot of time trying more complicated fixes when I should have trusted my gut about min-height.