### PR TITLE
Cleanup

### DIFF
--- a/src/components/MenuSection.svelte
+++ b/src/components/MenuSection.svelte
@@ -53,17 +53,16 @@
           <!-- Display item's image if it has one -->
           {#if item.productImage}
             <figure class="figure__menu-item-image">
-              <a href={item.productImage}>
-                <ImageLoader
-                  imageSlug={item.productImageSlug}
-                  allImages={item.allProductImages}
-                  processedImageSizes={item.productImageSizes}
-                  src={item.productImage}
-                  sizes={"160px"}
-                  alt={""}
-                  rounded={true}
-                />
-              </a>
+              <ImageLoader
+                thumbnail={true}
+                imageSlug={item.productImageSlug}
+                allImages={item.allProductImages}
+                processedImageSizes={item.productImageSizes}
+                src={item.productImage}
+                sizes={"160px"}
+                alt={""}
+                rounded={true}
+              />
               <figcaption>
                 <p>
                   {item.itemName}
@@ -88,17 +87,16 @@
           <!-- Image container will go here w/ its own class -->
           {#if item.productImage}
             <figure class="figure__menu-item-image">
-              <a href={item.productImage}>
-                <ImageLoader
-                  imageSlug={item.productImageSlug}
-                  allImages={item.allProductImages}
-                  processedImageSizes={item.productImageSizes}
-                  src={item.productImage}
-                  sizes={"160px"}
-                  alt={""}
-                  rounded={true}
-                />
-              </a>
+              <ImageLoader
+                thumbnail={true}
+                imageSlug={item.productImageSlug}
+                allImages={item.allProductImages}
+                processedImageSizes={item.productImageSizes}
+                src={item.productImage}
+                sizes={"160px"}
+                alt={""}
+                rounded={true}
+              />
               <figcaption>
                 <p>
                   <span class="bold">Protein:</span>
@@ -127,17 +125,16 @@
             <!-- Display item's image if it has one -->
             {#if item.productImage}
               <figure class="figure__menu-item-image">
-                <a href={item.productImage}>
-                  <ImageLoader
-                    imageSlug={item.productImageSlug}
-                    allImages={item.allProductImages}
-                    processedImageSizes={item.productImageSizes}
-                    src={item.productImage}
-                    sizes={"160px"}
-                    alt={""}
-                    rounded={true}
-                  />
-                </a>
+                <ImageLoader
+                  thumbnail={true}
+                  imageSlug={item.productImageSlug}
+                  allImages={item.allProductImages}
+                  processedImageSizes={item.productImageSizes}
+                  src={item.productImage}
+                  sizes={"160px"}
+                  alt={""}
+                  rounded={true}
+                />
                 <figcaption>
                   <p>
                     {item.itemName}

--- a/src/components/images/Image.svelte
+++ b/src/components/images/Image.svelte
@@ -1,4 +1,9 @@
 <script>
+  import ImageWrapper from './ImageWrapper.svelte'
+  
+  import { onMount } from "svelte";
+
+  export let thumbnail;
   export let imageSlug;
   export let allImages;
   export let processedImageSizes;
@@ -10,15 +15,16 @@
   export let rounded;
   export let ariaLabel;
 
-  import { onMount } from "svelte";
-
   let loaded = false;
   let thisImage;
+  let currentSrc;
+
 
   onMount(() => {
     if (thisImage) {
       thisImage.onload = () => {
         loaded = true;
+        currentSrc = thisImage.currentSrc
       };
     }
   });
@@ -28,46 +34,49 @@
   }
 </script>
 
-{#if allImages && processedImageSizes}
-  <picture>
-    {#each processedImageSizes as size}
-      <source
-        type="image/webp"
-        media={`
-          (min-width: ${size === "400" ? "10" : size}px)`}
-        srcset={src.replace(
-          `${imageSlug}.jpg`,
-          `${imageSlug}-${size}.webp ${size}w`
-        )}
-        {sizes}
-      />
-    {/each}
-    {#each processedImageSizes as size}
-      <source
-        type="image/jpeg"
-        media={`
-          (min-width: ${size === "400" ? "10" : size}px)`}
-        srcset={src.replace(
-          `${imageSlug}.jpg`,
-          `${imageSlug}-${size}.jpg ${size}w`
-        )}
-        {sizes}
-      />
-    {/each}
-    <img bind:this={thisImage} class:loaded class:rounded {src} {alt} />
-  </picture>
-{:else}
-  <img
-    {src}
-    {alt}
-    {width}
-    {height}
-    {ariaLabel}
-    class:loaded
-    class:rounded
-    bind:this={thisImage}
-  />
-{/if}
+<ImageWrapper {currentSrc} {thumbnail}>
+  <!-- ^ ImageWrapper component only wraps the slot content below in an <a> tag if thumbnail={true} was passed from parent/page, otherwise it just renders this component unchanged through a bare <slot> -->
+  {#if allImages && processedImageSizes}
+    <picture>
+      {#each processedImageSizes as size}
+        <source
+          type="image/webp"
+          media={`
+            (min-width: ${size === "400" ? "10" : size}px)`}
+          srcset={src.replace(
+            `${imageSlug}.jpg`,
+            `${imageSlug}-${size}.webp ${size}w`
+          )}
+          {sizes}
+        />
+      {/each}
+      {#each processedImageSizes as size}
+        <source
+          type="image/jpeg"
+          media={`
+            (min-width: ${size === "400" ? "10" : size}px)`}
+          srcset={src.replace(
+            `${imageSlug}.jpg`,
+            `${imageSlug}-${size}.jpg ${size}w`
+          )}
+          {sizes}
+        />
+      {/each}
+      <img bind:this={thisImage} class:loaded class:rounded {src} {alt} />
+    </picture>
+  {:else}
+    <img
+      {src}
+      {alt}
+      {width}
+      {height}
+      {ariaLabel}
+      class:loaded
+      class:rounded
+      bind:this={thisImage}
+    />
+  {/if}
+</ImageWrapper>
 
 <style>
   img {

--- a/src/components/images/ImageLoader.svelte
+++ b/src/components/images/ImageLoader.svelte
@@ -1,4 +1,8 @@
 <script>
+  import IntersectionObserver from "./IntersectionObserver.svelte";
+  import Image from "./Image.svelte";
+
+  export let thumbnail;
   export let imageSlug;
   export let allImages;
   export let sizes;
@@ -10,13 +14,12 @@
   export let rounded;
   export let ariaLabel;
 
-  import IntersectionObserver from "./IntersectionObserver.svelte";
-  import Image from "./Image.svelte";
 </script>
 
 <IntersectionObserver once={true} let:intersecting>
   {#if intersecting}
     <Image
+      {thumbnail}
       {imageSlug}
       {allImages}
       {processedImageSizes}

--- a/src/components/images/ImageWrapper.svelte
+++ b/src/components/images/ImageWrapper.svelte
@@ -1,0 +1,14 @@
+<script>
+
+  export let currentSrc
+  export let thumbnail
+
+</script>
+
+{#if currentSrc && thumbnail}
+  <a href={currentSrc}>
+    <slot></slot>
+  </a>
+{:else}
+  <slot></slot>
+{/if}


### PR DESCRIPTION
Using <picture> to dynamically load webp or jpeg at different sizes based on the viewport created a new problem: the <a> tags we'd been using to wrap images on the Menu Page couldn't "get" the dynamic img.currentSrc. So the thumbnail images that e.g. mobile users clicked on would end up downloading the huge source image instead of the optimized one shown on the page, defeating the whole purpose of image optimization for different screen sizes.

Created an ImageWrapper component that conditionally renders an <a> tag to wrap Image.svelte's content if thumbnail={true} gets passed into <ImageLoader>. This also catches whatever img.currentSrc is so when users click the link they'll always get the same optimized image they saw on the page.